### PR TITLE
Add milliseconds to time format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ error messages:
 
 Use chai-datetime to get something easier to read:
 
-    AssertionError: expected Thu May 30 2013 16:06:00 GMT-0400 (EDT) to equal Thu May 30 2013 16:05:00 GMT-0400 (EDT)
+    AssertionError: expected Thu May 30 2013 16:06:00.000 (-04:00) to equal Thu May 30 2013 16:05:00.000 (-04:00)
 
 ## Usage
 

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -21,12 +21,43 @@
 }(function(chai, utils){
   chai.datetime = chai.datetime || {};
 
+  function padNumber(num, length) {
+    var ret = '' + num;
+    var i = ret.length;
+
+    if (!isFinite(length)) {
+      length = 2;
+    }
+
+    for (i; i < length; i++) {
+      ret = '0' + ret;
+    }
+
+    return ret;
+  }
+
+  chai.datetime.getFormattedTimezone = function(timezoneInMinutes) {
+    var tz = Math.abs(timezoneInMinutes);
+    var hours = Math.floor(tz / 60);
+    var minutes = tz % 60;
+    var isAheadOfUtc = timezoneInMinutes <= 0;
+
+    return (isAheadOfUtc ? '+' : '-') +
+           padNumber(hours) + ':' +
+           padNumber(minutes);
+  }
+
   chai.datetime.formatDate = function(date) {
     return date.toDateString();
   };
 
   chai.datetime.formatTime = function(time) {
-    return time;
+    return time.toDateString() + ' ' +
+           padNumber(time.getHours()) + ':' +
+           padNumber(time.getMinutes()) + ':' +
+           padNumber(time.getSeconds()) + '.' +
+           padNumber(time.getMilliseconds(), 3) + ' (' +
+           chai.datetime.getFormattedTimezone(time.getTimezoneOffset()) + ')';
   };
 
   chai.datetime.equalTime = function(actual, expected) {

--- a/test/test.js
+++ b/test/test.js
@@ -391,7 +391,6 @@
       })
     });
 
-
     describe('beforeTime', function() {
       describe('when comparing two different times', function() {
         beforeEach(function() {
@@ -439,7 +438,6 @@
         });
       });
     });
-
 
     describe('afterTime', function() {
       describe('when comparing two different times', function() {
@@ -489,6 +487,83 @@
       });
     });
 
+    describe('formatTime', function() {
+      describe('printing the date at the start', function() {
+        it('prints the date at the beginning of the string', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 17, 345);
+          chai.datetime.formatTime(date).should.match(/^Sat Dec 20 2014.*/);
+        });
+      });
+
+      describe('printing the time', function() {
+        it('prints milliseconds with one digit', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 17, 002);
+          chai.datetime.formatTime(date).should.match(/.*15:20:17\.002.*/);
+        });
+
+        it('prints milliseconds with two digits', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 17, 097);
+          chai.datetime.formatTime(date).should.match(/.*15:20:17\.097.*/);
+        });
+
+        it('prints milliseconds with three digits', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 17, 345);
+          chai.datetime.formatTime(date).should.match(/.*15:20:17\.345.*/);
+        });
+
+        it('prints seconds with one digit', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 7, 345);
+          chai.datetime.formatTime(date).should.match(/.*15:20:07.*/);
+        });
+
+        it('prints seconds with two digits', function() {
+          var date = new Date(2014, 11, 20, 15, 20, 49, 345);
+          chai.datetime.formatTime(date).should.match(/.*15:20:49.*/);
+        });
+
+        it('prints minutes with one digit', function() {
+          var date = new Date(2014, 11, 20, 15, 6, 49, 345);
+          chai.datetime.formatTime(date).should.match(/.*15:06:49.*/);
+        });
+
+        it('prints minutes with two digits', function() {
+          var date = new Date(2014, 11, 20, 15, 31, 49, 345);
+          chai.datetime.formatTime(date).should.match(/.*15:31:49.*/);
+        });
+
+        it('prints hours with one digit', function() {
+          var date = new Date(2014, 11, 20, 3, 20, 49, 345);
+          chai.datetime.formatTime(date).should.match(/.*03:20:49.*/);
+        });
+
+        it('prints hours with two digits', function() {
+          var date = new Date(2014, 11, 20, 17, 20, 49, 345);
+          chai.datetime.formatTime(date).should.match(/.*17:20:49.*/);
+        });
+      });
+
+      describe('printing the timezone', function() {
+        it('prints the local timezone', function() {
+          var date = new Date('2014-12-20T15:20:17.345Z');
+          chai.datetime.formatTime(date).should.match(/.* \([+-]\d\d:\d\d\)$/);
+        });
+      });
+    });
+
+    describe('getFormattedTimezone', function() {
+      // Note, timezone is given in minutes, negative means it is ahead of UTC.
+      it('should use a + to indicate the timezone is ahead of UTC', function () {
+        chai.datetime.getFormattedTimezone(-525).should.equal('+08:45');
+      });
+
+      it('should use a - to indicate the timezone is behind of UTC', function () {
+        chai.datetime.getFormattedTimezone(300).should.equal('-05:00');
+      });
+
+      it('should use a + when we are in the UTC timezone', function () {
+        chai.datetime.getFormattedTimezone(0).should.equal('+00:00');
+      })
+    });
 
     describe('tdd alias', function() {
       beforeEach(function() {


### PR DESCRIPTION
I added milliseconds in the format HH:MM:SS.000 which seems to be the
standard after a little internet research.

Since there is not great formatting support in the JavaScript spec
right now, the format of the local timezone is not quite the same as
before. It will display it as the offset from UTC in hours without
any text description. This appears to be a common issue, as moment.js
ended up cutting this part of the date string due to cross-browser
issues.

An example of the date output after applying this commit is:
```
Sat Dec 20 2014 15:20:17.097 (-05:00)
```

This pull request fixes #18 